### PR TITLE
Update to v3.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "Jinja2" %}
-{% set version = "3.0.0" %}
-{% set sha256 = "ea8d7dd814ce9df6de6a761ec7f1cac98afe305b8cdc4aaae4e114b8d8ce24c5" %}
+{% set version = "3.0.1" %}
+{% set sha256 = "703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
Category:  miniconda
Popularity: 
Branch: v3.0.1
Version change: bump version number from 3.0.0 to 3.0.1
Update branch: https://github.com/AnacondaRecipes/jinja2-feedstock/blob/v3.0.1/recipe/meta.yaml
license: BSD-3-Clause
Release date: May 18, 2021, https://pypi.org/project/jinja2/#history
Changelog: significant changes https://jinja.palletsprojects.com/en/3.0.x/changes/#version-3-0-1
dev_url: https://github.com/pallets/jinja
Bug Tracker: new open https://github.com/pallets/jinja/issues/
Github releases: https://github.com/pallets/jinja/releases
Upstream setup.cfg: https://github.com/pallets/jinja//blob/main/setup.cfg
Upstream setup.py: https://github.com/pallets/jinja//blob/main/setup.py
Concourse builds correctly

Actions:
1. Updated a version number to 3.0.1 and SHA256 in meta.yaml from upstream source

Result:
- all-succeeded


The package jinja2 is inside the packages:
aiohttp-jinja2
airflow
altair
altair3_2
altiar
anaconda-project
astropy
bokeh
cctools-ld64
conda-build
conda-verify
cookiecutter
daal4py
filesystem-spec
flask
flask-babel
intake
jinja2
jinja2-time
jupyterhub
jupyterlab
jupyterlab_server
jupyter_server
libpysal
llvm-compilers
markupsafe
moto
mpld3
nbconvert
neon
notebook
numba
pandas-profiling
pims
pyerfa
pyramid_jinja2
python-nvd3
runipy
salt
sphinx
swagger-ui-bundle