### PR TITLE
Add patch to fix jinja2.Markup() issue in v3.0.0

### DIFF
--- a/recipe/f562a4fdea7bc10039ffa555367f8891e790ab53.patch
+++ b/recipe/f562a4fdea7bc10039ffa555367f8891e790ab53.patch
@@ -1,0 +1,23 @@
+From f562a4fdea7bc10039ffa555367f8891e790ab53 Mon Sep 17 00:00:00 2001
+From: David Lord <davidism@gmail.com>
+Date: Mon, 17 May 2021 06:41:42 -0700
+Subject: [PATCH] fix deprecated `Markup` subclass
+
+---
+
+ src/jinja2/utils.py | 2 +-
+
+
+diff --git a/src/jinja2/utils.py b/src/jinja2/utils.py
+index 85311747..2a2641c0 100644
+--- a/src/jinja2/utils.py
++++ b/src/jinja2/utils.py
+@@ -834,7 +834,7 @@ def __repr__(self) -> str:
+ 
+ 
+ class Markup(markupsafe.Markup):
+-    def __new__(cls, base, encoding=None, errors="strict"):  # type: ignore
++    def __new__(cls, base="", encoding=None, errors="strict"):  # type: ignore
+         warnings.warn(
+             "'jinja2.Markup' is deprecated and will be removed in Jinja"
+             " 3.1. Import 'markupsafe.Markup' instead.",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,14 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    # 6/1/2021: To fix "jinja2.Markup() fails without deprecation warning"
+    # see https://github.com/pallets/jinja/issues/1438
+    - f562a4fdea7bc10039ffa555367f8891e790ab53.patch
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -21,6 +25,7 @@ requirements:
     - pip
     - python >=3.6
     - setuptools
+    - wheel
 
   run:
     - python >=3.6
@@ -38,6 +43,7 @@ test:
 about:
   home: http://jinja.pocoo.org
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE.rst
   summary: An easy to use stand-alone template engine written in pure python.
   description: |


### PR DESCRIPTION
Added a patch to fix an issue with `jinja2.Markup() ` https://github.com/pallets/jinja/issues/1438

------
Category:  miniconda | subcategory:  core | pkg_type:  python
Popularity:  9832346 downloads -  jinja2  3.0.0  An easy to use stand-alone template engine written in pure python.  
Branch: v3.0.0_with_patch
Version change: 3.0.0, no change
Update branch: https://github.com/AnacondaRecipes/jinja2-feedstock/blob/v3.0.0_with_patch/recipe/meta.yaml
  license: BSD-3-Clause
Release date: May 12, 2021, https://pypi.org/project/jinja2/#history
Changelog: breaking changes https://jinja.palletsprojects.com/en/3.0.x/changes/
Bug Tracker: new open https://github.com/pallets/jinja/issues/
Github releases: https://github.com/pallets/jinja/releases
Upstream setup.cfg: https://github.com/pallets/jinja//blob/main/setup.cfg
Upstream setup.py: https://github.com/pallets/jinja//blob/main/setup.py
Concourse builds correctly

Actions:

1. Add patch to fix jinja2.Markup() issue in v3.0.0
2. Add missing package wheel
3. Add license_family
4. Bump build number to 1