### PR TITLE
Update to 3.0.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  skip: True  # [py<36]
   noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,6 @@ requirements:
     - wheel
   run:
     - python >=3.6
-    - setuptools
     - markupsafe >=2.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "Jinja2" %}
-{% set version = "3.0.0" %}
-{% set sha256 = "ea8d7dd814ce9df6de6a761ec7f1cac98afe305b8cdc4aaae4e114b8d8ce24c5" %}
+{% set version = "3.0.2" %}
+{% set sha256 = "827a0e32839ab1600d4eb1c4c33ec5a8edfbc5cb42dafa13b81f182f97784b45" %}
 
 package:
   name: {{ name|lower }}
@@ -12,6 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
+  skip: True  # [py<36]
   noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
@@ -19,9 +20,9 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
     - setuptools
-
+    - wheel
   run:
     - python >=3.6
     - setuptools
@@ -30,14 +31,16 @@ requirements:
 test:
   imports:
     - jinja2
-  commands:
-    - pip check
   requires:
     - pip
+    - python <3.10
+  commands:
+    - pip check
 
 about:
   home: http://jinja.pocoo.org
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE.rst
   summary: An easy to use stand-alone template engine written in pure python.
   description: |


### PR DESCRIPTION
Category:  miniconda | subcategory:  core | pkg_type:  python
Popularity:  12288034 downloads -  jinja2  3.0.2  An easy to use stand-alone template engine written in pure python.
Version change: bump version number from 3.0.0 to v3.0.2
  license: BSD-3-Clause
Release date:  Oct 5, 2021
Bug Tracker: new open issues https://github.com/pallets/jinja/issues
Github changelog: https://github.com/pallets/jinja/blob/main/CHANGES.rst
License: https://github.com/pallets/jinja/blob/main/LICENSE.rst
Upstream setup.py: https://github.com/pallets/jinja/blob/3.0.2/setup.py
Upstream setup.cfg: https://github.com/pallets/jinja/blob/3.0.2/setup.cfg


The package jinja2 is mentioned inside the packages:
aiohttp-jinja2 | airflow | altair | altair3_2 | altiar | anaconda-project | astropy | bokeh | cctools-ld64 | conda-build | conda-verify | connexion | cookiecutter | daal4py | distributed | filesystem-spec | flask | flask-babel | intake | jinja2-time | jupyterhub | jupyterlab | jupyterlab_server | jupyter_server | libpysal | llvm-compilers | markupsafe | moto | mpld3 | nbconvert | neon | notebook | numba | pandas-profiling | pims | pyerfa | pyramid_jinja2 | python-3.7 | python-nvd3 | runipy | salt | sphinx | swagger-ui-bundle |

Actions:
1. Add missing wheel in host
2. Add python <3.10 in test/requires
3. Add license_family
4. Remove setuptools from run

Result:
- all-succeeded