### PR TITLE
[PKG-3870] Update to 3.1.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "Jinja2" %}
-{% set version = "3.1.2" %}
-{% set sha256 = "31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852" %}
+{% set version = "3.1.3" %}
+{% set sha256 = "ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90" %}
 
 package:
   name: {{ name|lower }}
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: True  # [py<37]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,12 +27,16 @@ requirements:
     - python
 
 test:
+  source_files:
+    - tests
   requires:
     - pip
+    - pytest
   imports:
     - jinja2
   commands:
     - pip check
+    - pytest tests -v
 
 about:
   home: https://palletsprojects.com/p/jinja/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,6 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.rst
-  license_url: https://github.com/pallets/jinja/blob/{{ version }}/LICENSE.rst
   summary: A very fast and expressive template engine.
   description: |
     Jinja is a fast, expressive, extensible templating engine. Special
@@ -67,7 +66,6 @@ about:
     restricting functionality too much.
   doc_url: https://jinja.palletsprojects.com/
   dev_url: https://github.com/pallets/jinja/
-  doc_source_url: https://github.com/pallets/jinja/tree/{{ version }}/docs
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Jinja2 3.1.3

**Destination channel:** defaults

### Links

- [PKG-3870](https://anaconda.atlassian.net/browse/PKG-3870) 
- [Upstream repository](https://github.com/pallets/jinja/)
- [Upstream changelog/diff](https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-3)

### Explanation of changes:

- Added upstream tests.
- Removed redundant doc_source_url and license_url.


[PKG-3870]: https://anaconda.atlassian.net/browse/PKG-3870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ